### PR TITLE
Move Employees to different vessel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)

--- a/app/controllers/manage/settings/vessels_controller.rb
+++ b/app/controllers/manage/settings/vessels_controller.rb
@@ -41,11 +41,17 @@ module Manage
         @vessel = scope.find(params[:id])
         authorize([:manage, :settings, @vessel])
         if @vessel.destroy
+          assign_employees
           redirect_back fallback_location: edit_manage_organization_settings_meta_data_path,
                         flash: { success: "Vessel removed!" }
         else
           render "edit", flash: { danger: "There were issues removing the vessel" }
         end
+      end
+
+      def remove
+        @vessel = scope.find(params[:id])
+        authorize([:manage, :settings, @vessel])
       end
 
       private
@@ -56,6 +62,14 @@ module Manage
 
       def vessel_params
         params.require(:vessel).permit(:id, :name)
+      end
+
+      def assign_employees
+        return if params[:assign_to_id].blank?
+
+        assign_to = scope.find(params[:assign_to_id])
+        assign_to.employments << @vessel.employments
+        assign_to.save!
       end
     end
   end

--- a/app/policies/manage/settings/vessel_policy.rb
+++ b/app/policies/manage/settings/vessel_policy.rb
@@ -22,6 +22,10 @@ module Manage
       def destroy?
         true
       end
+
+      def remove?
+        true
+      end
     end
   end
 end

--- a/app/views/manage/settings/meta_data/edit.html.erb
+++ b/app/views/manage/settings/meta_data/edit.html.erb
@@ -41,12 +41,14 @@
                                 action: "modal-remote-trigger#show",
                                 "modal-remote-trigger-id": "remote_modal",
                                 cy: "vessel-#{v.id}-edit"
-                              } %><!--
-                  --><%= link_to icon(:trash).html_safe, manage_organization_settings_vessel_path(@organization, v),
-                              method: :delete,
-                              title: "Remove",
+                              } %>
+                  <%= link_to icon(:trash).html_safe, 
+                              remove_manage_organization_settings_vessel_path(@organization, v),
+                              remote: true,
                               data: {
-                                confirm: "Are you sure you want to remove #{v.name}?",
+                                controller: "modal-remote-trigger",
+                                action: "modal-remote-trigger#show",
+                                "modal-remote-trigger-id": "remote_modal",
                                 cy: "vessel-#{v.id}-remove"
                               }  %>
                 </td>

--- a/app/views/manage/settings/vessels/_modal_remove.html.erb
+++ b/app/views/manage/settings/vessels/_modal_remove.html.erb
@@ -1,0 +1,42 @@
+<%= component "modal", title: "#{action_name.titleize} Vessel", content_only: true do |c| %>
+  <% c.body do %>
+    <%= form_with url: {
+                    controller: controller_name,
+                    action: :destroy,
+                  },
+                  method: :delete,
+                  builder: WrappedFormBuilder,
+                  remote: true do |f| %>
+      <div class="modal__body">
+        <div class="l-row u-mb">
+          <div class="l-col-xs-26 l-col-sm-22">
+            <p>Do you wish to move the connected user to another existing vessel?</p>
+          </div>
+        </div>
+        <%= f.select :assign_to_id,
+              options_for_select(@organization.vessels.where.not(id: @vessel.id).by_name.collect {|v| [ v.name, v.id ] }),
+              { include_blank: "Do not move users", label: 'Move users to vessel' },
+              data: { cy: "select-vessel" } 
+        %>
+      </div>
+      <div class="modal__footer">
+        <%= button_tag "Cancel",
+                       type: :button,
+                       class: "btn--link u-mr u-text-muted",
+                       data: { 
+                         target: "form-activation.action",
+                         action: "modal#hide",
+                         cy: "vessel-cancel"
+                       } 
+        %>
+        <%= f.submit "Remove",
+          class: "btn btn--primary",
+          data: {
+            cy: "vessel-submit",
+            disable_with: "Removing"
+          }
+        %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/manage/settings/vessels/remove.js.erb
+++ b/app/views/manage/settings/vessels/remove.js.erb
@@ -1,0 +1,1 @@
+PubSub.publish('modalContentLoaded', {content: '<%= j(render(partial: "manage/settings/vessels/modal_remove")) %>'});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,11 @@ Rails.application.routes.draw do
       namespace :settings do
         resource :organization, only: %i[edit update]
         resource :meta_data, only: %i[edit]
-        resources :vessels, except: %i[index]
+        resources :vessels, except: %i[index] do
+          member do
+            get :remove
+          end
+        end
       end
     end
   end

--- a/cypress/integration/manage/settings/vessels_spec.js
+++ b/cypress/integration/manage/settings/vessels_spec.js
@@ -26,18 +26,27 @@ describe("Manage > Settings > Vessels", () => {
   });
 
   it("remove an existing vessel", () => {
-    cy.on("window:confirm", () => {
-      return true;
-    });
     cy.get("[data-cy=vessel-1-remove]").click();
+    cy.get("[data-cy=vessel-submit]").click();
     cy.get("[data-cy=vessel-1]").should("not.exist");
   });
 
-  it("skip removing existing vessel with confirmation modal", () => {
-    cy.on("window:confirm", () => {
-      return false;
+  it("remove current and assign employees to other vessel", () => {
+    cy.get("[data-cy=vessel-2]").within(() => {
+      cy.contains("View (0)");
     });
     cy.get("[data-cy=vessel-1-remove]").click();
+    cy.get("[data-cy=select-vessel]").select("2");
+    cy.get("[data-cy=vessel-submit]").click();
+    cy.get("[data-cy=vessel-1]").should("not.exist");
+    cy.get("[data-cy=vessel-2]").within(() => {
+      cy.contains("View (1)");
+    });
+  });
+
+  it("skip removing existing vessel with confirmation modal", () => {
+    cy.get("[data-cy=vessel-1-remove]").click();
+    cy.get("[data-cy=vessel-cancel]").click();
     cy.get("[data-cy=vessel-1]");
   });
 });


### PR DESCRIPTION
### Description

This feature let you assign the employees of the vessel you want to delete
to any other available vessel.

**Steps to test**

1. Go to `Manage > Settings > Meta Data`
2. Try to delete one of the vessel.
3. Make sure a modal is open with an option of 'Move Users To Vessel'
4. Make sure you can select the target vessel and employees should migrate to selected vessel.
